### PR TITLE
#15 Feature flag CodeLens integration, don't combine globs that use glob conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Run your .Net Core tests using the
 Property                            | Description
 ------------------------------------|---------------------------------------------------------------
 `dotnetCoreExplorer.searchpatterns` | The glob describing the location of your test assemblies (relative to the workspace folder) (default: `["**/bin/**/*.{dll,exe}"]`)
-`dotnetCoreExplorer.skippatterns`    | Assemblies to skip from searching for tests.(default: `["**/{nunit,xunit}.*.dll"]`, i.e.: exclude any files starting with nunit.\*.dll or xunit.\*.dll)
+`dotnetCoreExplorer.skippatterns`   | Assemblies to skip from searching for tests.(default: `["**/{nunit,xunit}.*.dll"]`, i.e.: exclude any files starting with nunit.\*.dll or xunit.\*.dll)
 `dotnetCoreExplorer.runEnvVars`     | Additional environment variables that your project needs present while running tests (default: `{}`)
+`dotnetCoreExplorer.codeLens`       | Enable CodeLens symbol integration with the [C# Omnisharp VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) (default: `true`)
 
 
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Run your .Net Core tests using the
 
 Property                            | Description
 ------------------------------------|---------------------------------------------------------------
-`dotnetCoreExplorer.searchpatterns` | The glob describing the location of your test assemblies (relative to the workspace folder) (default: `["**/bin/**/*.{dll,exe}"]`)
-`dotnetCoreExplorer.skippatterns`   | Assemblies to skip from searching for tests.(default: `["**/{nunit,xunit}.*.dll"]`, i.e.: exclude any files starting with nunit.\*.dll or xunit.\*.dll)
+`dotnetCoreExplorer.searchpatterns` | An array of glob patterns describing the location of your test assemblies (relative to the workspace folder) (default: `["**/bin/**/*.{dll,exe}"]`)
+`dotnetCoreExplorer.skippattern`    | Assemblies to skip from searching for tests. (default: `"**/{nunit,xunit}.*.dll"`, i.e.: exclude any files starting with nunit.\*.dll or xunit.\*.dll)
 `dotnetCoreExplorer.runEnvVars`     | Additional environment variables that your project needs present while running tests (default: `{}`)
 `dotnetCoreExplorer.codeLens`       | Enable CodeLens symbol integration with the [C# Omnisharp VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) (default: `true`)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Andrew Bridge (http://github.com/andrewbridge)"
   ],
   "publisher": "derivitec-ltd",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "homepage": "https://github.com/Derivitec/vscode-dotnet-adapter",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,12 @@
           "default": {},
           "scope": "resource"
         },
+        "dotnetCoreExplorer.codeLens": {
+          "description": "enable CodeLens symbol integration with the C# Omnisharp VSCode extension",
+          "type": "boolean",
+          "default": true,
+          "scope": "resource"
+        },
         "dotnetCoreExplorer.logpanel": {
           "description": "write diagnotic logs to an output panel",
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -62,16 +62,11 @@
       "type": "object",
       "title": ".Net Core Test Explorer",
       "properties": {
-        "dotnetCoreExplorer.skippatterns": {
-          "description": "Array of patterns skip assemblies",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "scope": "resource",
-          "default": [
-            "**/{nunit,xunit}.*.dll"
-          ]
+        "dotnetCoreExplorer.skippattern": {
+          "description": "Pattern to skip assemblies",
+          "type": "string",
+          "default": "**/{nunit,xunit}.*.dll",
+          "scope": "resource"
         },
         "dotnetCoreExplorer.searchpatterns": {
           "description": "array of your test files or directory (relative to the workspace folder)",

--- a/src/CodeLensProcessor.ts
+++ b/src/CodeLensProcessor.ts
@@ -25,16 +25,16 @@ export default class CodeLensProcessor {
             this.setupOnOmnisharpReady();
         } else {
             this.output.update('CodeLens integration deactivated. Change the codeLens setting if you wish to activate.');
-            this.disposables.push(
-                this.configManager.addWatcher('codeLens', (newValue: boolean) => {
-                    if (newValue === true && !this.waiting && !this.ready) {
-                        this.setupOnOmnisharpReady();
-                        return;
-                    }
-                    this.output.update('CodeLens integration was previously activated and is already in progress.');
-                })
-            );
         }
+        this.disposables.push(
+            this.configManager.addWatcher('codeLens', (newValue: boolean) => {
+                if (newValue === true && !this.waiting && !this.ready) {
+                    this.setupOnOmnisharpReady();
+                    return;
+                }
+                this.output.update('CodeLens integration was previously activated and is already in progress.');
+            })
+        );
     }
 
     private async setupOnOmnisharpReady() {

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -47,6 +47,7 @@ export class ConfigManager {
     private setupConfigChangeListeners() {
         const disposeListener = vscode.workspace.onDidChangeConfiguration(configChange => {
             this.log.info('Configuration changed');
+            this.config = vscode.workspace.getConfiguration('dotnetCoreExplorer', this.workspace.uri);
             const activeWatchers = this.configKeys.filter(key => this.watchers[key].size > 0);
             activeWatchers.forEach((key) => {
                 if (configChange.affectsConfiguration(`dotnetCoreExplorer.${key}`, this.workspace.uri)) {

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode';
 import { Log } from 'vscode-test-adapter-util';
-import { createConfigItem as c } from './utilities';
+import { createConfigItem as c, plural } from './utilities';
 
 const schema = {
     logpanel: c<boolean>({ default: false }),
+    codeLens: c<boolean>({ default: true }),
     runEnvVars: c<object>({ default: {} }),
     searchpatterns: c<string[]>({ default: [], required: true }),
-    skippattern: c<string[]>({ default: [] }),
+    skippatterns: c<string[]>({ default: [] }),
 };
 
 type ConfigSchema = typeof schema;
@@ -15,16 +16,52 @@ type ConfigEntryKey = keyof ConfigSchema;
 
 type ConfigEntryType<T extends ConfigEntryKey> = ConfigSchema[T] extends ConfigEntry<infer U> ? U : any;
 
+type ConfigWatchers = { [K in keyof ConfigSchema]: Set<Function> };
+
 export class ConfigManager {
+    private disposables: { dispose(): void }[] = [];
+
     private config: vscode.WorkspaceConfiguration;
 
     private schema = schema;
+
+    private watchers: ConfigWatchers;
 
     constructor(
         private readonly workspace: vscode.WorkspaceFolder,
 		private readonly log: Log,
 	){
         this.config = vscode.workspace.getConfiguration('dotnetCoreExplorer', this.workspace.uri);
+        this.watchers = this.initWatchers();
+        this.setupConfigChangeListeners();
+    }
+
+    private initWatchers() {
+        const watchers = {} as ConfigWatchers;
+        this.configKeys.forEach((key) => {
+            watchers[key] = new Set();
+        });
+        return watchers;
+    }
+
+    private setupConfigChangeListeners() {
+        const disposeListener = vscode.workspace.onDidChangeConfiguration(configChange => {
+            this.log.info('Configuration changed');
+            const activeWatchers = this.configKeys.filter(key => this.watchers[key].size > 0);
+            activeWatchers.forEach((key) => {
+                if (configChange.affectsConfiguration(`dotnetCoreExplorer.${key}`, this.workspace.uri)) {
+                    const keyWatchers = this.watchers[key];
+                    const watcherCount = keyWatchers.size;
+                    this.log.info(`Change affects ${key} which has ${watcherCount} watcher${plural(watcherCount)}`);
+                    keyWatchers.forEach(func => func(this.get(key)));
+                }
+            });
+        });
+        this.disposables.push(disposeListener);
+    }
+
+    private get configKeys(): ConfigEntryKey[] {
+        return Object.keys(schema) as ConfigEntryKey[];
     }
 
     public get<T extends ConfigEntryKey>(key: T): ConfigEntryType<T> {
@@ -44,4 +81,16 @@ export class ConfigManager {
         if (noValue || wrongType) return schemaEntry.default as ConfigEntryType<T>;
         return value;
     }
+
+    public addWatcher<T extends ConfigEntryKey>(key: T, cb: Function) {
+        this.watchers[key].add(cb);
+        return { dispose: () => this.watchers[key].delete(cb) };
+    }
+
+    dispose(): void {
+		for (const disposable of this.disposables) {
+			disposable.dispose();
+		}
+		this.disposables = [];
+	}
 }

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -7,7 +7,7 @@ const schema = {
     codeLens: c<boolean>({ default: true }),
     runEnvVars: c<object>({ default: {} }),
     searchpatterns: c<string[]>({ default: [], required: true }),
-    skippatterns: c<string[]>({ default: [] }),
+    skippattern: c<string>({ default: '' }),
 };
 
 type ConfigSchema = typeof schema;

--- a/src/TestDiscovery.ts
+++ b/src/TestDiscovery.ts
@@ -9,9 +9,8 @@ import CodeLensProcessor from './CodeLensProcessor';
 import TestExplorer from './TestExplorer';
 import { combineGlobPatterns } from './utilities';
 
-export class TestDiscovery {
-	private readonly configManager: ConfigManager;
 
+export class TestDiscovery {
 	private Loadingtest: Command | undefined;
 
 	private loadStatus: Loaded;
@@ -30,11 +29,11 @@ export class TestDiscovery {
 		private readonly workspace: vscode.WorkspaceFolder,
 		private readonly nodeMap: Map<string, DerivitecSuiteContext | DerivitecTestContext>,
 		private readonly output: OutputManager,
+		private readonly configManager: ConfigManager,
 		private readonly codeLens: CodeLensProcessor,
 		private readonly testExplorer: TestExplorer,
 		private readonly log: Log,
 	){
-		this.configManager = new ConfigManager(this.workspace, this.log);
 		this.loadStatus = this.output.loaded;
     }
 
@@ -102,7 +101,7 @@ export class TestDiscovery {
     private async LoadFiles(searchpattern: string): Promise<string[]> {
 		const stopLoader = this.output.loader();
 		const findGlob = new vscode.RelativePattern(this.workspace.uri.fsPath, searchpattern);
-		const skipGlob = combineGlobPatterns(this.configManager.get('skippattern'));
+		const skipGlob = combineGlobPatterns(this.configManager.get('skippatterns'));
 		let files: string[] = [];
 		for (const file of await vscode.workspace.findFiles(findGlob, skipGlob)) {
 			files.push(file.fsPath);

--- a/src/TestRunner.ts
+++ b/src/TestRunner.ts
@@ -14,19 +14,16 @@ import OutputManager from './OutputManager';
 const getMethodName = (fullName: string) => fullName.substr(fullName.lastIndexOf('.') + 1);
 
 export class TestRunner {
-	private readonly configManager: ConfigManager;
-
 	private Runningtest: Command | undefined;
 
     constructor(
 		private readonly workspace: vscode.WorkspaceFolder,
 		private readonly nodeMap: Map<string, DerivitecSuiteContext | DerivitecTestContext>,
 		private readonly output: OutputManager,
+		private readonly configManager: ConfigManager,
 		private readonly log: Log,
         private readonly testExplorer: TestExplorer,
-	) {
-		this.configManager = new ConfigManager(this.workspace, this.log);
-	}
+	) {}
 
     public Run(tests: string[]): Promise<void> {
         return this.InnerRun(tests, false);

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -10,7 +10,11 @@ const createConfigItem = <T>({ default: defaultVal, ...optional }: Partial<Confi
     ...optional
 }) as ConfigEntry<T>;
 
-const combineGlobPatterns = (patterns: string[]) => patterns.length === 1 ? patterns[0] : `{${patterns.join(',')}}`;
+// We can combine glob patterns together, but we can't nest group conditions in vscode
+const optimiseGlobPatterns = (patterns: string[]) => {
+    if (patterns.every(pattern => pattern.indexOf('{') === -1)) return [`{${patterns.join(',')}}`];
+    return patterns;
+}
 
 const plurals = {
     '': 's',
@@ -47,7 +51,7 @@ const getDate = () => new Date().toISOString();
 export {
     getUid,
     createConfigItem,
-    combineGlobPatterns,
+    optimiseGlobPatterns,
     plural,
     objToListSentence,
     readFileAsync,


### PR DESCRIPTION
Fixes an issue where VSCode didn't allow nested group conditions in globs such as `{**/*{nunit,xunit}.dll,**/node_modules/**}`. This often occurred when we tried to combine globs together for efficiency.

We now use a optimisation strategy where we always loop round multiple search patterns, but will optionally condense the number of individual search patterns if group conditions aren't used. This optimisation can be improved in the future.

We also combine config watching logic into the ConfigManager and only use one instance of the config manager across the codebase. This allows easy watching across the codebase as well as disposal of watchers.