### PR TITLE
Test discovery improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2020-02-19
 ### Added
 - Collect and report various errors encountered during discovery in a non-noisy way
 - Report various error encountered during file watcher update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
+# Changelog
+All notable changes to this project will be documented in this file.
 
-## [0.8] - 27-1-2020
-### New
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Collect and report various errors encountered during discovery in a non-noisy way
+- Report various error encountered during file watcher update
+- Reporting file search and test loading separately during load operation
+- Detecting errors encountered by `vstest` during discovery
+- Detecting suites without test methods as a discovery error
+
+### Changed
+- Pipe `vstest` output to ".Net Core Test Output" pane during discovery
+- Use VSCode `workspace.fs` API for performant, compatible file operations
+
+### Fixed
+- Loaded counts are reset prior to each load
+- Previously reloading or updating (via file watchers) the suite was additive causing duplicate tests to appear. New suites replace old ones where the suite id matches
+- Loaded count summarisation didn't correctly construct sentences when some counts were zero
+
+## [1.1.0] - 2020-02-18
+### Added
+- CodeLens integration can be disabled via a new `codeLens` setting. You'll need to reload the project for this to take effect
+
+### Changed
+- The `skippatterns` array setting has changed to a string based `skippattern` setting. This is due to the glob optimising issue mentioned in "Fixed".
+
+### Fixed
+- The adapter would previously attempt to optimise test discovery by combining glob patterns in the `searchpatterns` and `skippatterns` settings. This was done using the group condition syntax (i.e. `{a,b}`). When one of the provided glob patterns also used the group condition syntax, VSCode would throw an unreported error as it does not allow nested group conditions. We no longer apply this optimisation to `skippatterns` (which is why this is now a single string; see "Changed") and only apply the optimisation to `searchpatterns` where the syntax isn't used.
+
+[More detail about this release](https://github.com/Derivitec/vscode-dotnet-adapter/pull/16)
+
+## [1.0.1] - 2020-02-17
+### Fixed
+- Bumped patch and rebuilt due to case sensitivity issue that built mismatching files
+
+## [1.0.0] - 2020-02-14
+### Added
+- Initial published release
+
+## [0.8] - 2020-01-27
+### Added
  - Initial release.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Andrew Bridge (http://github.com/andrewbridge)"
   ],
   "publisher": "derivitec-ltd",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "homepage": "https://github.com/Derivitec/vscode-dotnet-adapter",
   "repository": {

--- a/src/OutputManager.ts
+++ b/src/OutputManager.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { plural, objToListSentence, getDate } from './utilities';
+import Command from './Command';
 
 const loadedDefault = () => ({
     loaded: 0,
@@ -102,6 +103,10 @@ ${this.log.join('\n')}`);
                 this.update(`${id} finished`);
             }
         };
+    }
+
+    connectCommand(cmd: Command) {
+        cmd.onData(data => this.outputChannel.append(data.toString()));
     }
 
     resetLoaded() {

--- a/src/TestDiscovery.ts
+++ b/src/TestDiscovery.ts
@@ -1,19 +1,26 @@
 import Command from './Command';
 import * as vscode from 'vscode';
 import { Log } from 'vscode-test-adapter-util';
-import * as fs from 'fs';
 
 import { ConfigManager } from "./ConfigManager";
 import OutputManager, { Loaded } from './OutputManager';
 import CodeLensProcessor from './CodeLensProcessor';
 import TestExplorer from './TestExplorer';
-import { optimiseGlobPatterns } from './utilities';
+import { optimiseGlobPatterns, getFileFromPath, getErrStr } from './utilities';
 
+const fs = vscode.workspace.fs;
+
+enum DISCOVERY_ERROR {
+	VSTEST_STDERR = 'DISCOVERY_ERROR: VSTEST_STDERR',
+	SYMBOL_FILE_EMPTY = 'DISCOVERY_ERROR: SYMBOL_FILE_EMPTY'
+};
 
 export class TestDiscovery {
 	private Loadingtest: Command | undefined;
 
 	private loadStatus: Loaded;
+
+	private loadErrors = new Map<string, unknown>();
 
     private SuitesInfo: DerivitecTestSuiteInfo = {
 		type: 'suite',
@@ -59,6 +66,8 @@ export class TestDiscovery {
 		this.output.update('Searching for tests');
 		const files = await this.LoadFiles(searchPatterns);
 		this.loadStatus.loaded += files.length;
+		this.output.update(`Loading tests from ${files.length} files`);
+		const stopLoader = this.output.loader();
 		for (const file of files) {
 			try {
 				this.log.info(`file: ${file} (loading)`);
@@ -69,6 +78,22 @@ export class TestDiscovery {
 				throw e;
 			}
 		};
+		stopLoader();
+
+		if (this.loadErrors.size > 0) {
+			this.output.update(`Encountered errors in ${this.loadErrors.size} files during loading.`)
+			const errArr = Array.from(this.loadErrors.entries());
+			if (errArr.some(([file, err]) => err === DISCOVERY_ERROR.VSTEST_STDERR)) {
+				this.output.update(`Some of these errors were encountered by vstest. See ".NET Core Test Output" pane for details.`);
+			}
+			const emptyErr = errArr.filter(([file, err]) => err === DISCOVERY_ERROR.SYMBOL_FILE_EMPTY);
+			if (emptyErr.length > 0) {
+				let err = `The following assemblies produced empty symbol files. If there are test methods in this project, try reloading.\n`;
+				err += emptyErr.map(([file]) => file).join('\n');
+				this.output.update(err);
+			}
+			this.loadErrors.clear();
+		}
 
 		// Create watchers
 		this.watchers = searchPatterns.map(pattern => this.setupWatcher(pattern));
@@ -115,22 +140,25 @@ export class TestDiscovery {
 		const testListFile = `${file}.txt`;
 		let newFile = false;
 		try {
-			const cacheStat = fs.statSync(testListFile);
-			const fileStat = fs.statSync(file);
+			const cacheStat = await fs.stat(vscode.Uri.parse(testListFile));
+			const fileStat = await fs.stat(vscode.Uri.parse(file));
 			if (cacheStat.mtime > fileStat.mtime) {
 				this.loadStatus.addedFromCache += 1;
 				this.AddtoSuite(file);
 				return;
 			}
 		} catch(err) {
-			if (err instanceof Error && err.message.indexOf('no such file')) {
+			const msg = getErrStr(err);
+			if (msg.indexOf('non-existing file')) {
 				newFile = true;
 				this.log.debug(`No cache file for ${testListFile}`);
 			} else {
 				this.log.error(`Unable to check for a cache file for ${testListFile}; Encountered: ${err}`);
+				this.handleLoadError(file, err);
 			}
 		}
 
+		let error = false;
 		const args: string[] = [
 			'vstest',
 			file,
@@ -139,27 +167,37 @@ export class TestDiscovery {
 		];
 		this.log.debug(`execute: dotnet ${args.join(' ')} (starting)`);
 		this.Loadingtest = new Command('dotnet', args, { cwd: this.workspace.uri.fsPath});
-		this.Loadingtest.onData(data => this.output.update(data.toString()));
+		this.output.connectCommand(this.Loadingtest);
+		this.Loadingtest.onStdErr(() => {
+			error = true;
+		})
+		const previousChildCount = this.SuitesInfo.children.length;
 		try {
 			const code = await this.Loadingtest.exitCode;
+			if (error) throw DISCOVERY_ERROR.VSTEST_STDERR;
 			this.log.debug(`execute: dotnet ${args.join(' ')} (complete)`);
 			this.Loadingtest = undefined;
 			this.log.info(`child process exited with code ${code}`);
 			if (newFile) this.loadStatus.addedFromFile += 1;
 			else this.loadStatus.updatedFromFile += 1;
-			this.AddtoSuite(file);
+			await this.AddtoSuite(file);
 		} catch (err) {
 			this.log.error(`child process exited with error ${err}`);
-			this.SuitesInfo.children.length = 0;
+			this.handleLoadError(file, err);
+			if (previousChildCount !== this.SuitesInfo.children.length) {
+				// If AddtoSuite has some how died mid run, adding a corrupt suite, return the array length to pre-add length
+				this.SuitesInfo.children.length = previousChildCount;
+			}
 			if (this.Loadingtest) this.Loadingtest.dispose();
 			this.Loadingtest = undefined;
 		}
     }
 
-    private AddtoSuite(file: string) {
+    private async AddtoSuite(file: string) {
 		this.log.info(`suite creation: ${file} (starting)`);
 
-		const output = fs.readFileSync(`${file}.txt`).toString()
+		const testFile = vscode.Uri.parse(`${file}.txt`);
+		const output = (await fs.readFile(testFile)).toString()
 		let lines = output.split(/[\n\r]+/);
 
 		const pathItems = file.split('/');
@@ -219,6 +257,12 @@ export class TestDiscovery {
 			this.nodeMap.set(testInfo.id, {node: testInfo});
 			classContext.node.children.push(testInfo);
 		}
+
+		if (!fileSuite.children.length) {
+			// Nothing has been added, which means there aren't any symbols in this file, delete it in case of error
+			this.log.info(`suite creation:: ${file} was empty (erroring)`);
+			throw DISCOVERY_ERROR.SYMBOL_FILE_EMPTY;
+		}
 		this.log.info(`suite creation:: ${file} (complete)`);
 
 	}
@@ -239,10 +283,22 @@ export class TestDiscovery {
 		const add = async (uri: vscode.Uri) => {
 			if (typeof this.Loadingtest !== 'undefined') await this.Loadingtest.exitCode;
 			const finish = await this.testExplorer.load();
+			const file = getFileFromPath(uri.fsPath);
 			this.output.resetLoaded()
 			this.loadStatus.loaded += 1;
 			try {
 				await this.SetTestSuiteInfo(uri.fsPath);
+				if (this.loadErrors.size > 0 && this.loadErrors.has(file)) {
+					const loadError = this.loadErrors.get(file);
+					let err = `An error occurred while loading ${file}: `;
+					if (loadError === DISCOVERY_ERROR.VSTEST_STDERR) {
+						err += 'See ".NET Core Test Output" pane for details.';
+					} else if (loadError === DISCOVERY_ERROR.SYMBOL_FILE_EMPTY) {
+						err += 'The symbols file produced was empty, are there tests in this project?';
+					}
+					this.output.update(err);
+					this.loadErrors.clear();
+				}
 				// Send to CodeLensProcessor; Do NOT wait for it as it'll cause a deadlock
 				this.codeLens.process(this.SuitesInfo);
 				this.output.update(`New tests added from ${uri.fsPath.replace(this.workspace.uri.fsPath, '')}`, true);
@@ -255,6 +311,20 @@ export class TestDiscovery {
 		watcher.onDidCreate(add);
 		watcher.onDidDelete((uri) => this.ResetSuites(uri.fsPath));
 		return watcher;
+	}
+
+	private async handleLoadError(file: string, err: unknown) {
+		const testListFile = `${file}.txt`;
+		this.loadErrors.set(getFileFromPath(file), err);
+		try {
+			await fs.delete(vscode.Uri.parse(testListFile));
+		} catch (err) {
+			const msg = getErrStr(err);
+			// If the error is due to the file already being deleted, don't raise an error in the log
+			if (msg.indexOf('non-existing file') === -1) {
+				this.log.error(`Unable to delete ${testListFile}: ${msg}`);
+			}
+		}
 	}
 
 	public dispose() {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -28,11 +28,14 @@ const plural = (count: number, word: keyof typeof plurals = '') => {
 
 const objToListSentence = (obj: { [key: string]: number }, ignoreZeros = true) => {
     let str = '';
-    Object.entries(obj).forEach(([key, value], i, arr) => {
+    let entries = Object.entries(obj);
+    if (ignoreZeros) {
+        entries = entries.filter(([key, value]) => value !== 0);
+    }
+    entries.forEach(([key, value], i, arr) => {
         const needsJoiner = str.length > 0;
         const last = arr.length - 1 === i;
         const joiner = last ? ' and ' : ', ';
-        if (value === 0 && ignoreZeros) return;
         if (needsJoiner) str += joiner;
         str += `${value} ${key}`;
     });
@@ -48,6 +51,14 @@ const readFileAsync = (filePath: string, options?: object) => new Promise((resol
 
 const getDate = () => new Date().toISOString();
 
+const getFileFromPath = (path: string) => path.substr(path.lastIndexOf('/') + 1);
+
+const getErrStr = (err: any) => {
+    if (err instanceof Error) return err.message;
+    if (typeof err === 'string') return err;
+    return err.toString();
+}
+
 export {
     getUid,
     createConfigItem,
@@ -56,4 +67,6 @@ export {
     objToListSentence,
     readFileAsync,
     getDate,
+    getFileFromPath,
+    getErrStr,
 }


### PR DESCRIPTION
Fixes #18 
Fixes #14 
Fixes #9 

- Added a CHANGELOG
- Provided a simple method of piping `Command` output to the user, part of fixes for #9 
- Began collecting and explaining errors encountered during a load or update process, this reduces noise in the summary pane and provides raw output in the output pane, part of fixes for #9 
- Moved to using VSCode's `workspace.fs` API [as per docs](https://code.visualstudio.com/api/references/vscode-api#FileSystem)

> The file system interface exposes the editor's built-in and contributed file system providers. It allows extensions to work with files from the local disk as well as files from remote places, like the remote extension host or ftp-servers.

> The workspace offers support for listening to fs events and for finding files. Both perform well and run outside the editor-process so that they should be always used instead of nodejs-equivalents.

- Trigger failures when commands hit the `stderr`, part of fixes for #14 
- Trigger failures when an assembly yields no tests, part of fixes for #14 
- Check if a suite already exists and handle replacement rather than addition to the suite list, part of fixes for #18 
- Fix ResetSuites to dispose of all mappings to old test objects, helps with de-duplication and GC'ing, part of fixes for #18 
- Fix load count summarisation, previously summarised sentences only ended with  "and" if the last item was non-zero. Now zeroes are filtered out prior to sentence building.