### PR TITLE
File path handling improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2020-07-28
+### Fixed
+- Improve cross-platform and remote development compatibility during file operations [(#29)](https://github.com/Derivitec/vscode-dotnet-adapter/pull/29)
+
 ## [1.4.0] - 2020-07-31
 ### Added
 - `searchpatterns` now additionally accepts an object to allow test grouping. Check the updated README for usage information. [(#31)](https://github.com/Derivitec/vscode-dotnet-adapter/pull/31)

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ type TestSuiteInfo = import('vscode-test-adapter-api').TestSuiteInfo;
 type TestInfo = import('vscode-test-adapter-api').TestInfo;
 type TestSuiteEvent = import('vscode-test-adapter-api').TestSuiteEvent;
 type TestEvent = import('vscode-test-adapter-api').TestEvent;
+type VSCodeUri = import('vscode').Uri;
 
 type UngroupedSearchPatterns = string | string[];
 type GroupedSearchPatterns = { [key: string]: UngroupedSearchPatterns };
@@ -13,13 +14,13 @@ type SearchPatterns = UngroupedSearchPatterns | GroupedSearchPatterns;
 
 interface DerivitecTestSuiteInfo extends TestSuiteInfo {
     children: (DerivitecTestSuiteInfo | DerivitecTestInfo)[];
-    sourceDll: string;
     parent: DerivitecTestSuiteInfo | null;
+    sourceDll: VSCodeUri | 'root';
 }
 
 interface DerivitecTestInfo extends TestInfo {
-    sourceDll: string;
     parent: DerivitecTestSuiteInfo | null;
+    sourceDll: VSCodeUri;
 }
 
 interface DerivitecSuiteContext {

--- a/src/TestDiscovery.ts
+++ b/src/TestDiscovery.ts
@@ -32,6 +32,8 @@ const removeNodeFromParent = (parent: DerivitecTestSuiteInfo['parent'], term: st
 	}
 }
 
+const getTestFile = (file: vscode.Uri) => file.with({ path: `${file.path}.txt`});
+
 export class TestDiscovery {
 	private Loadingtest: Command | undefined;
 
@@ -123,9 +125,9 @@ export class TestDiscovery {
 		const stopLoader = this.output.loader();
 		for (const file of files) {
 			try {
-				this.log.info(`file: ${file} (loading)`);
+				this.log.info(`file: ${file.fsPath} (loading)`);
 				await this.SetTestSuiteInfo(file);
-				this.log.info(`file: ${file} (load complete)`);
+				this.log.info(`file: ${file.fsPath} (load complete)`);
 			} catch (e) {
 				this.log.error(e);
 				throw e;
@@ -174,25 +176,26 @@ export class TestDiscovery {
 		await this.Loadingtest.exitCode;
 	}
 
-    private async LoadFiles(searchpatterns: string[]): Promise<string[]> {
+    private async LoadFiles(searchpatterns: string[]): Promise<vscode.Uri[]> {
 		const stopLoader = this.output.loader();
 		const skipGlob = this.configManager.get('skippattern');
-		let files: string[] = [];
+		let files: vscode.Uri[] = [];
 		await Promise.all(searchpatterns.map(async (pattern) => {
 			const findGlob = new vscode.RelativePattern(this.workspace.uri.fsPath, pattern);
 			const results = await vscode.workspace.findFiles(findGlob, skipGlob);
-			files.push(...results.map(file => file.fsPath));
+			files.push(...results);
 		}));
 		stopLoader();
 		return files;
 	}
 
-    private async SetTestSuiteInfo(file: string): Promise<void> {
-		const testListFile = `${file}.txt`;
+    private async SetTestSuiteInfo(file: vscode.Uri): Promise<void> {
+		const testListFile = getTestFile(file);
+		const testListFileStr = testListFile.fsPath;
 		let newFile = false;
 		try {
-			const cacheStat = await fs.stat(vscode.Uri.file(testListFile));
-			const fileStat = await fs.stat(vscode.Uri.file(file));
+			const cacheStat = await fs.stat(testListFile);
+			const fileStat = await fs.stat(file);
 			if (cacheStat.mtime > fileStat.mtime) {
 				this.loadStatus.addedFromCache += 1;
 				await this.AddtoSuite(file);
@@ -202,9 +205,9 @@ export class TestDiscovery {
 			const msg = getErrStr(err);
 			if (msg.indexOf('non-existing file') > -1) {
 				newFile = true;
-				this.log.debug(`No cache file for ${testListFile}`);
+				this.log.debug(`No cache file for ${testListFileStr}`);
 			} else {
-				this.log.error(`Unable to check for a cache file for ${testListFile}; Encountered: ${err}`);
+				this.log.error(`Unable to check for a cache file for ${testListFileStr}; Encountered: ${err}`);
 				this.handleLoadError(file, err);
 			}
 		}
@@ -212,9 +215,9 @@ export class TestDiscovery {
 		let error = false;
 		const args: string[] = [
 			'vstest',
-			file,
+			file.fsPath,
 			'/ListFullyQualifiedTests',
-			`/ListTestsTargetPath:${testListFile}`
+			`/ListTestsTargetPath:${testListFileStr}`
 		];
 		this.log.debug(`execute: dotnet ${args.join(' ')} (starting)`);
 		this.Loadingtest = new Command('dotnet', args, { cwd: this.workspace.uri.fsPath});
@@ -239,14 +242,15 @@ export class TestDiscovery {
 		}
     }
 
-    private async AddtoSuite(file: string) {
-		this.log.info(`suite creation: ${file} (starting)`);
+    private async AddtoSuite(file: vscode.Uri) {
+		const fileStr = file.fsPath;
+		this.log.info(`suite creation: ${fileStr} (starting)`);
 
-		const testFile = vscode.Uri.file(`${file}.txt`);
+		const testFile = getTestFile(file);
 		const output = (await fs.readFile(testFile)).toString()
 		let lines = output.split(/[\n\r]+/);
 
-		const pathItems = file.split('/');
+		const pathItems = fileStr.split('/');
 		const fileNamespace = pathItems[pathItems.length - 1].replace(".dll", "");
 
 		const fileSuite: DerivitecTestSuiteInfo = {
@@ -322,22 +326,27 @@ export class TestDiscovery {
 
 		if (!fileSuite.children.length) {
 			// Nothing has been added, which means there aren't any symbols in this file, delete it in case of error
-			this.log.info(`suite creation: ${file} was empty (erroring)`);
+			this.log.info(`suite creation: ${fileStr} was empty (erroring)`);
 			/* if (previousChildCount !== this.SuitesInfo.children.length) {
 				// If AddtoSuite has some how died mid run, adding a corrupt suite, return the array length to pre-add length
 				this.SuitesInfo.children.length = previousChildCount;
 			} */
 			throw DISCOVERY_ERROR.SYMBOL_FILE_EMPTY;
 		}
-		this.log.info(`suite creation: ${file} (complete)`);
+		this.log.info(`suite creation: ${fileStr} (complete)`);
 		this.AttachSuite(fileSuite);
 	}
 
 	private GetSuiteGroup(suite: DerivitecTestSuiteInfo) {
 		const groupPair = { name: 'root', group: this.SuitesInfo };
 		const patterns = this.searchPatterns;
+		const filePath = suite.sourceDll;
+		if (filePath === 'root') {
+			// Unlikely to happen, but this is a structual suite and cannot be part of a group
+			return groupPair;
+		}
 		if (hasGrouping(patterns) && this.SuiteGroups) {
-			const name = Object.keys(patterns).find((groupName) => isMatch(suite.sourceDll, patterns[groupName]));
+			const name = Object.keys(patterns).find((groupName) => isMatch(filePath.fsPath, patterns[groupName]));
 			if (!name) return groupPair;
 			return { name, group: this.SuiteGroups[name] };
 		}
@@ -345,6 +354,8 @@ export class TestDiscovery {
 	}
 
 	private AttachSuite(suite: DerivitecTestSuiteInfo) {
+		const filePath = suite.sourceDll;
+		if (filePath === 'root') throw Error('Cannot attach structual suite.');
 		const { name: parentName, group: parent } = this.GetSuiteGroup(suite);
 		let inserted = false;
 		if (this.nodeMap.has(suite.id)) {
@@ -352,14 +363,14 @@ export class TestDiscovery {
 			if (context.node.parent === parent) {
 				// Just detach, no removal
 				// Swap suite in place
-				this.DetachSuite(context.node.sourceDll);
+				this.DetachSuite(filePath);
 				const suiteIndex = parent.children.findIndex(childSuite => childSuite.sourceDll === suite.sourceDll);
 				if (suiteIndex && suiteIndex > -1) {
 					this.log.info(`replacing node "${suite.id}" in "${parentName}"`);
 					parent.children[suiteIndex] = suite;
 					inserted = true;
 				}
-			} else {
+			} else if (context.node.sourceDll !== 'root') {
 				this.log.info(`removing node "${suite.id}" from "${parentName}"`);
 				this.DetachSuite(context.node.sourceDll, true);
 			}
@@ -394,7 +405,8 @@ export class TestDiscovery {
 	}
 
 	/* remove all tests of module fn from Suite */
-	private DetachSuite(filePath: string, removeSuite: boolean = false) {
+	private DetachSuite(file: vscode.Uri, removeSuite: boolean = false) {
+		const filePath = file.toString();
 		// Remove all nodes related to given DLL, otherwise stale nodes live on and aren't accessible in the UI and aren't GCable
 		this.nodeMap.forEach((value,key) => {
 			if (value.node.sourceDll === filePath) {
@@ -413,12 +425,13 @@ export class TestDiscovery {
 			if (typeof this.Loadingtest !== 'undefined') await this.Loadingtest.exitCode;
 			const finish = await this.testExplorer.load();
 			const file = getFileFromPath(uri.fsPath);
+			const uriStr = uri.toString();
 			this.output.resetLoaded()
 			this.loadStatus.loaded += 1;
 			try {
-				await this.SetTestSuiteInfo(uri.fsPath);
-				if (this.loadErrors.size > 0 && this.loadErrors.has(file)) {
-					const loadError = this.loadErrors.get(file);
+				await this.SetTestSuiteInfo(uri);
+				if (this.loadErrors.size > 0 && this.loadErrors.has(uriStr)) {
+					const loadError = this.loadErrors.get(uriStr);
 					let err = `An error occurred while loading ${file}: `;
 					if (loadError === DISCOVERY_ERROR.VSTEST_STDERR) {
 						err += 'See ".NET Core Test Output" pane for details.';
@@ -438,20 +451,20 @@ export class TestDiscovery {
 		}
 		watcher.onDidChange(add);
 		watcher.onDidCreate(add);
-		watcher.onDidDelete((uri) => this.DetachSuite(uri.fsPath, true));
+		watcher.onDidDelete((uri) => this.DetachSuite(uri, true));
 		return watcher;
 	}
 
-	private async handleLoadError(file: string, err: unknown) {
-		const testListFile = `${file}.txt`;
-		this.loadErrors.set(getFileFromPath(file), err);
+	private async handleLoadError(file: vscode.Uri, err: unknown) {
+		const testListFile = getTestFile(file);
+		this.loadErrors.set(file.toString(), err);
 		try {
-			await fs.delete(vscode.Uri.file(testListFile));
+			await fs.delete(testListFile);
 		} catch (err) {
 			const msg = getErrStr(err);
 			// If the error is due to the file already being deleted, don't raise an error in the log
 			if (msg.indexOf('non-existing file') === -1) {
-				this.log.error(`Unable to delete ${testListFile}: ${msg}`);
+				this.log.error(`Unable to delete ${testListFile.fsPath}: ${msg}`);
 			}
 		}
 	}

--- a/src/TestDiscovery.ts
+++ b/src/TestDiscovery.ts
@@ -191,8 +191,8 @@ export class TestDiscovery {
 		const testListFile = `${file}.txt`;
 		let newFile = false;
 		try {
-			const cacheStat = await fs.stat(vscode.Uri.parse(testListFile));
-			const fileStat = await fs.stat(vscode.Uri.parse(file));
+			const cacheStat = await fs.stat(vscode.Uri.file(testListFile));
+			const fileStat = await fs.stat(vscode.Uri.file(file));
 			if (cacheStat.mtime > fileStat.mtime) {
 				this.loadStatus.addedFromCache += 1;
 				await this.AddtoSuite(file);
@@ -242,7 +242,7 @@ export class TestDiscovery {
     private async AddtoSuite(file: string) {
 		this.log.info(`suite creation: ${file} (starting)`);
 
-		const testFile = vscode.Uri.parse(`${file}.txt`);
+		const testFile = vscode.Uri.file(`${file}.txt`);
 		const output = (await fs.readFile(testFile)).toString()
 		let lines = output.split(/[\n\r]+/);
 
@@ -446,7 +446,7 @@ export class TestDiscovery {
 		const testListFile = `${file}.txt`;
 		this.loadErrors.set(getFileFromPath(file), err);
 		try {
-			await fs.delete(vscode.Uri.parse(testListFile));
+			await fs.delete(vscode.Uri.file(testListFile));
 		} catch (err) {
 			const msg = getErrStr(err);
 			// If the error is due to the file already being deleted, don't raise an error in the log

--- a/src/TestDiscovery.ts
+++ b/src/TestDiscovery.ts
@@ -202,8 +202,7 @@ export class TestDiscovery {
 				return;
 			}
 		} catch(err) {
-			const msg = getErrStr(err);
-			if (msg.indexOf('non-existing file') > -1) {
+			if ('code' in err && err.code === 'FileNotFound' || getErrStr(err).indexOf('non-existing file') > -1) {
 				newFile = true;
 				this.log.debug(`No cache file for ${testListFileStr}`);
 			} else {

--- a/src/TestResultsFile.ts
+++ b/src/TestResultsFile.ts
@@ -70,9 +70,8 @@ function updateUnitTestDefinitions(xml: Element, results: TestResult[]): void {
     }
 }
 
-const parseTestResults = async (filePath: string): Promise<TestResult[]> => {
+const parseTestResults = async (fileUri: vscode.Uri): Promise<TestResult[]> => {
     let results: TestResult[];
-    const fileUri = vscode.Uri.file(filePath)
     const data = (await fs.readFile(fileUri)).toString();
     const xdoc = new DOMParser().parseFromString(data, "application/xml");
     results = parseUnitTestResults(xdoc.documentElement);

--- a/src/TestResultsFile.ts
+++ b/src/TestResultsFile.ts
@@ -1,9 +1,10 @@
 "use strict";
-import * as fs from "fs";
+import * as vscode from 'vscode';
 //@ts-ignore
 import { DOMParser, Element, Node } from "xmldom";
 import { TestResult } from "./TestResult";
-import { readFileAsync } from './utilities';
+
+const fs = vscode.workspace.fs;
 
 function findChildElement(node: Node, name: string): Node {
     let child = node.firstChild;
@@ -71,14 +72,15 @@ function updateUnitTestDefinitions(xml: Element, results: TestResult[]): void {
 
 const parseTestResults = async (filePath: string): Promise<TestResult[]> => {
     let results: TestResult[];
-    const data = await readFileAsync(filePath);
+    const fileUri = vscode.Uri.file(filePath)
+    const data = (await fs.readFile(fileUri)).toString();
     const xdoc = new DOMParser().parseFromString(data, "application/xml");
     results = parseUnitTestResults(xdoc.documentElement);
 
     updateUnitTestDefinitions(xdoc.documentElement, results);
 
     try {
-        fs.unlinkSync(filePath);
+        await fs.delete(fileUri);
     } catch {}
 
     return results;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,5 +1,3 @@
-import * as fs from 'fs';
-
 const toString36 = (num: number) => num.toString(36).substr(2);
 
 const getUid = () => toString36(Math.random()) + toString36(Date.now());
@@ -55,13 +53,6 @@ const objToListSentence = (obj: { [key: string]: number }, ignoreZeros = true) =
     return str;
 }
 
-const readFileAsync = (filePath: string, options?: object) => new Promise((resolve, reject) => {
-    fs.readFile(filePath, { encoding: 'utf8', ...options }, (err, data) => {
-        if (err) return reject(err);
-        resolve(data);
-    });
-});
-
 const getDate = () => new Date().toISOString();
 
 const getFileFromPath = (path: string) => path.substr(path.lastIndexOf('/') + 1);
@@ -79,7 +70,6 @@ export {
     getPatternArray,
     plural,
     objToListSentence,
-    readFileAsync,
     getDate,
     getFileFromPath,
     getErrStr,


### PR DESCRIPTION
This removes all handling of file paths as strings from the codebase.

Doing so was causing issues with ambiguous file strings, such as:

- a Windows file path where the drive letter could be interpreted as a URI protocol or scheme
- a file path which included `#` symbols which could lead to the rest of the path being interpreted as a URI fragment

We now rely on VSCode URI objects and only deal with strings for:

- URI comparison
- URI printing
- use of URIs as a command line argument

Finally, we also remove all reliance on native node filesystem packages, as VSCode provides alternative methods which cater for remote development scenarios.

Fixes #26 
Fixes #27 