### PR TITLE
Normalise errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2020-08-01
+### Fixed
+- Fix adapter breaking error handling in edge case scenarios [(#34)](https://github.com/Derivitec/vscode-dotnet-adapter/pull/34)
+
 ## [1.4.1] - 2020-07-31
 ### Fixed
 - Improve cross-platform and remote development compatibility during file operations [(#29)](https://github.com/Derivitec/vscode-dotnet-adapter/pull/29)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Andrew Bridge (http://github.com/andrewbridge)"
   ],
   "publisher": "derivitec-ltd",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "homepage": "https://github.com/Derivitec/vscode-dotnet-adapter",
   "repository": {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -62,8 +62,7 @@ const getFileFromPath = (path: string) => path.substr(path.lastIndexOf('/') + 1)
 const normaliseError = (err: any): { name: string, message: string } => {
     const unknownName = 'Unknown';
     const unknownMessage = 'An unknown error occurred';
-    if (err instanceof vscode.FileSystemError) return err;
-    if (err instanceof Error) return Object.assign(err, { name: unknownName });
+    if (err instanceof Error) return err;
     if (err === null) return { name: 'NULL', message: 'A null value was returned' };
     if (typeof err === 'object' && (!('name' in err) || !('message' in err))) return Object.assign(err, { name: err.name || unknownName, message: err.message || unknownMessage });
     if (typeof err === 'object') return err;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+
 const toString36 = (num: number) => num.toString(36).substr(2);
 
 const getUid = () => toString36(Math.random()) + toString36(Date.now());
@@ -57,10 +59,16 @@ const getDate = () => new Date().toISOString();
 
 const getFileFromPath = (path: string) => path.substr(path.lastIndexOf('/') + 1);
 
-const getErrStr = (err: any) => {
-    if (err instanceof Error) return err.message;
-    if (typeof err === 'string') return err;
-    return err.toString();
+const normaliseError = (err: any): { name: string, message: string } => {
+    const unknownName = 'Unknown';
+    const unknownMessage = 'An unknown error occurred';
+    if (err instanceof vscode.FileSystemError) return err;
+    if (err instanceof Error) return Object.assign(err, { name: unknownName });
+    if (err === null) return { name: 'NULL', message: 'A null value was returned' };
+    if (typeof err === 'object' && (!('name' in err) || !('message' in err))) return Object.assign(err, { name: err.name || unknownName, message: err.message || unknownMessage });
+    if (typeof err === 'object') return err;
+    if (typeof err === 'string') return { name: err, message: err };
+    return { name: unknownName, message: unknownMessage };
 }
 
 export {
@@ -72,5 +80,5 @@ export {
     objToListSentence,
     getDate,
     getFileFromPath,
-    getErrStr,
+    normaliseError,
 }


### PR DESCRIPTION
When detecting specific errors we make assumptions about the type. This has caused #33.

Parse errors into a uniform error object in order to improve runtime type safety.

Fixes #33