### PR TITLE
fix: change omnisharp extension name

### DIFF
--- a/src/CodeLensProcessor.ts
+++ b/src/CodeLensProcessor.ts
@@ -3,7 +3,7 @@ import OutputManager from './OutputManager';
 import TestExplorer from './TestExplorer';
 import { ConfigManager } from './ConfigManager';
 
-const getOmnisharp = () => vscode.extensions.getExtension('ms-vscode.csharp');
+const getOmnisharp = () => vscode.extensions.getExtension('ms-dotnettools.csharp');
 
 export default class CodeLensProcessor {
     private disposables: { dispose(): void }[] = [];


### PR DESCRIPTION
Fix part of https://github.com/Derivitec/vscode-dotnet-adapter/issues/36
new name of omnisharp extension is `ms-dotnettools.csharp`.
https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp