### PR TITLE
fix: Test discovery fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Andrew Bridge (http://github.com/andrewbridge)"
   ],
   "publisher": "derivitec-ltd",
-  "version": "1.4.3",
+  "version": "1.4.2",
   "license": "MIT",
   "homepage": "https://github.com/Derivitec/vscode-dotnet-adapter",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Andrew Bridge (http://github.com/andrewbridge)"
   ],
   "publisher": "derivitec-ltd",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "homepage": "https://github.com/Derivitec/vscode-dotnet-adapter",
   "repository": {

--- a/src/CodeLensProcessor.ts
+++ b/src/CodeLensProcessor.ts
@@ -3,7 +3,7 @@ import OutputManager from './OutputManager';
 import TestExplorer from './TestExplorer';
 import { ConfigManager } from './ConfigManager';
 
-const getOmnisharp = () => vscode.extensions.getExtension('ms-vscode.csharp');
+const getOmnisharp = () => vscode.extensions.getExtension('ms-dotnettools.csharp');
 
 export default class CodeLensProcessor {
     private disposables: { dispose(): void }[] = [];

--- a/src/TestDiscovery.ts
+++ b/src/TestDiscovery.ts
@@ -254,7 +254,8 @@ export class TestDiscovery {
 		const output = (await fs.readFile(testFile)).toString();
 		let lines = output.split(/[\n\r]+/);
 
-		const fileNamespace = path.parse(fileStr).base.replace(/(\.dll|\.exe)$/gi, "");
+		const parsedPath = path.parse(fileStr);
+		const fileNamespace = parsedPath.base.replace(parsedPath.ext, "");
 
 		const fileSuite: DerivitecTestSuiteInfo = {
 			type: "suite",

--- a/src/TestExplorer.ts
+++ b/src/TestExplorer.ts
@@ -7,7 +7,7 @@ import QueueManager from './QueueManager';
 
 type CompletionHandle<T> = (data: T) => void;
 
-type CompletionHandleWithFailure<T, P> = { pass: CompletionHandle<T>, fail: CompletionHandle<P> };
+type CompletionHandleWithFailure<T, P> = { pass: CompletionHandle<T>, fail: CompletionHandle<P>; };
 
 enum OP_TYPE { LOAD, RUN };
 const opPriority = [OP_TYPE.RUN, OP_TYPE.LOAD];
@@ -15,13 +15,11 @@ const opPriority = [OP_TYPE.RUN, OP_TYPE.LOAD];
 type LoadState = 'none' | 'started' | 'finished';
 
 export default class TestExplorer {
-    private disposables: { dispose(): void }[] = [];
+    private disposables: { dispose(): void; }[] = [];
 
-    private readonly testsEmitter =
-        new vscode.EventEmitter<TestLoadStartedEvent | TestLoadFinishedEvent>();
+    private readonly testsEmitter = new vscode.EventEmitter<TestLoadStartedEvent | TestLoadFinishedEvent>();
 
-	private readonly testStatesEmitter = new vscode.EventEmitter<TestRunStartedEvent |
-        TestRunFinishedEvent | TestSuiteEvent | TestEvent>();
+    private readonly testStatesEmitter = new vscode.EventEmitter<TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent>();
 
     private readonly autorunEmitter = new vscode.EventEmitter<void>();
 
@@ -42,15 +40,15 @@ export default class TestExplorer {
         );
     }
 
-	get tests(): vscode.Event<TestLoadStartedEvent | TestLoadFinishedEvent> {
-		return this.testsEmitter.event;
-	}
-	get testStates(): vscode.Event<TestRunStartedEvent | TestRunFinishedEvent |
-		TestSuiteEvent | TestEvent> {
-		return this.testStatesEmitter.event;
-	}
-	get autorun(): vscode.Event<void> | undefined {
-		return this.autorunEmitter.event;
+    get tests(): vscode.Event<TestLoadStartedEvent | TestLoadFinishedEvent> {
+        return this.testsEmitter.event;
+    }
+    get testStates(): vscode.Event<TestRunStartedEvent | TestRunFinishedEvent |
+        TestSuiteEvent | TestEvent> {
+        return this.testStatesEmitter.event;
+    }
+    get autorun(): vscode.Event<void> | undefined {
+        return this.autorunEmitter.event;
     }
 
     get testsRunning() {
@@ -77,7 +75,7 @@ export default class TestExplorer {
             this.loadState = 'finished';
             this.testsEmitter.fire(data);
             release();
-        }
+        };
         return {
             pass: (suite: DerivitecTestSuiteInfo) => finish({ type: 'finished', suite }),
             fail: (errorMessage: string) => finish({ type: 'finished', errorMessage })
@@ -90,14 +88,14 @@ export default class TestExplorer {
         // Add tests to the run pool to allow proper cancellation handling later
         tests.forEach(test => this.runPool.add(test));
         const release = await this.queueManager.acquireSlot(OP_TYPE.RUN);
-		return () => {
+        return () => {
             // Remove tests from the run pool
             tests.forEach(test => this.runPool.delete(test));
             if (this.queueManager.count[OP_TYPE.RUN] === 0) {
                 this.testStatesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
             }
             release();
-        }
+        };
     }
 
     cancelAllRuns() {
@@ -122,6 +120,6 @@ export default class TestExplorer {
 
     dispose(): void {
         this.disposables.forEach(disposable => disposable.dispose());
-		this.disposables = [];
+        this.disposables = [];
     }
 }


### PR DESCRIPTION
Supersedes #38, making a small tweak and reverting the version number until a version commit

@vchirikov in #38 
> Fix test discovery on windows (path parsing):
> Main change is:
> 
> ```js
> const fileNamespace = path.parse(fileStr).base.replace(/(\.dll|\.exe)$/gi, "");
> ```

Change is now:

```js
const parsedPath = path.parse(fileStr);
const fileNamespace = parsedPath.base.replace(parsedPath.ext, "");
```

> 
> Other formatting changes are:
> * adding semicolons
> * fixing the mixing of spaces-tabs in a single file
> 
> Fix: #36 