### PR TITLE
run tests in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Property                            | Description
 `dotnetCoreExplorer.skippattern`    | Assemblies to skip from searching for tests. (default: `"**/{nunit,xunit}.*.dll"`, i.e.: exclude any files starting with nunit.\*.dll or xunit.\*.dll)<br><br>Files already excluded by the `files.exclude` or `search.exclude` VSCode settings will also be skipped by the test adapter (ensure you can see dll files in the file explorer) (see [#35](https://github.com/Derivitec/vscode-dotnet-adapter/issues/35) for more detail)
 `dotnetCoreExplorer.runEnvVars`     | Additional environment variables that your project needs present while running tests (default: `{}`)
 `dotnetCoreExplorer.codeLens`       | Enable CodeLens symbol integration with the [C# Omnisharp VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) (default: `true`)
+`dotnetCoreExplorer.maxCpuCount`    | Enable parallel test execution. If value is zero then parallel process count is not limited (default: 1)
 
 
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@types/micromatch": "^4.0.1",
     "micromatch": "^4.0.2",
+    "p-limit": "^3.0.2",
     "tslib": "^1.9.3",
     "vscode-test-adapter-api": "^1.1.0",
     "vscode-test-adapter-util": "^0.5.1",
@@ -102,6 +103,13 @@
           "description": "enable CodeLens symbol integration with the C# Omnisharp VSCode extension",
           "type": "boolean",
           "default": true,
+          "scope": "resource"
+        },
+        "dotnetCoreExplorer.maxCpuCount": {
+          "description": "Enable parallel test execution. If value is zero then parallel process count is not limited",
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
           "scope": "resource"
         },
         "dotnetCoreExplorer.logpanel": {

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -10,6 +10,7 @@ const schema = {
     searchpatterns: c<SearchPatterns>({ default: [],
         typecheck: (value) => typeof value === 'object' || typeof value === 'string', required: true }),
     skippattern: c<string>({ default: '' }),
+    maxCpuCount: c<number>({ default: 1 }),
 };
 
 type ConfigSchema = typeof schema;

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,6 +425,18 @@ osenv@^0.1.3:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-limit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
+  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
+  dependencies:
+    p-try "^2.0.0"
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
 parse-semver@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parse-semver/-/parse-semver-1.1.1.tgz#9a4afd6df063dc4826f93fba4a99cf223f666cb8"


### PR DESCRIPTION
This pull request introduces ability to run tests in parallel. It would work when executing `root` tests or selecting several tests in "Test explorer ui". If you have more than one test dll then those will be executed in parallel.
In case you have more test dlls than cpu cores then parallel process count can be limited via `dotnetCoreExplorer.maxCpuCount` setting. Default value is 1 - so that extension behavior won't change for previous installations.