### PR TITLE
improve codelens processor's performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Property                            | Description
 `dotnetCoreExplorer.searchpatterns` | A string, array or object of search patterns which match your test files (relative to the workspace folder).<br><br>Arrays can be used to specify multiple differing patterns.<br>Objects can be used to provide test grouping, where the key is the group name and the value is either a glob pattern string or an array of glob pattern strings (see [#31](https://github.com/Derivitec/vscode-dotnet-adapter/pull/31) for more detail). (default: `"**/bin/**/*.{dll,exe}"`)
 `dotnetCoreExplorer.skippattern`    | Assemblies to skip from searching for tests. (default: `"**/{nunit,xunit}.*.dll"`, i.e.: exclude any files starting with nunit.\*.dll or xunit.\*.dll)<br><br>Files already excluded by the `files.exclude` or `search.exclude` VSCode settings will also be skipped by the test adapter (ensure you can see dll files in the file explorer) (see [#35](https://github.com/Derivitec/vscode-dotnet-adapter/issues/35) for more detail)
 `dotnetCoreExplorer.runEnvVars`     | Additional environment variables that your project needs present while running tests (default: `{}`)
-`dotnetCoreExplorer.codeLens`       | Enable CodeLens symbol integration with the [C# Omnisharp VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) (default: `true`)
+`dotnetCoreExplorer.codeLens`       | Enable CodeLens symbol integration with the [C# Omnisharp VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) (default: `true`)<br><br>In case test discovery takes very long time with `codeLens` enabled then it is recommended to use `"omnisharp.maxFindSymbolsItems": 0`
 
 
 


### PR DESCRIPTION
This pull request attempts to improve test discovery performance when codelens is enabled.
Changes were tested with 12 test projects in solution that contains around 1500 tests in total. Before it was taking more than 3 minutes till test discovery completed after each rebuild. With this PR it takes 13 seconds.

Could be related to #13 