### PR TITLE
Add settingsPath config property

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Property                            | Description
 `dotnetCoreExplorer.searchpatterns` | A string, array or object of search patterns which match your test files (relative to the workspace folder).<br><br>Arrays can be used to specify multiple differing patterns.<br>Objects can be used to provide test grouping, where the key is the group name and the value is either a glob pattern string or an array of glob pattern strings (see [#31](https://github.com/Derivitec/vscode-dotnet-adapter/pull/31) for more detail). (default: `"**/bin/**/*.{dll,exe}"`)
 `dotnetCoreExplorer.skippattern`    | Assemblies to skip from searching for tests. (default: `"**/{nunit,xunit}.*.dll"`, i.e.: exclude any files starting with nunit.\*.dll or xunit.\*.dll)<br><br>Files already excluded by the `files.exclude` or `search.exclude` VSCode settings will also be skipped by the test adapter (ensure you can see dll files in the file explorer) (see [#35](https://github.com/Derivitec/vscode-dotnet-adapter/issues/35) for more detail)
 `dotnetCoreExplorer.runEnvVars`     | Additional environment variables that your project needs present while running tests (default: `{}`)
+`dotnetCoreExplorer.settingsPath`   | Path to a settings file configuring the tests (default: `""`)
 `dotnetCoreExplorer.codeLens`       | Enable CodeLens symbol integration with the [C# Omnisharp VSCode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) (default: `true`)
 
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,12 @@
           "default": {},
           "scope": "resource"
         },
+        "dotnetCoreExplorer.settingsPath": {
+          "description": "Path to a settings file configuring the tests",
+          "type": "string",
+          "default": "",
+          "scope": "resource"
+        },
         "dotnetCoreExplorer.attachCpp": {
           "description": "Attach C++ debugging during test debugging",
           "type": "boolean",

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -7,6 +7,7 @@ const schema = {
     logpanel: c<boolean>({ default: false }),
     codeLens: c<boolean>({ default: true }),
     runEnvVars: c<object>({ default: {} }),
+    settingsPath: c<string>({ default: '' }),
     searchpatterns: c<SearchPatterns>({ default: [],
         typecheck: (value) => typeof value === 'object' || typeof value === 'string', required: true }),
     skippattern: c<string>({ default: '' }),

--- a/src/TestRunner.ts
+++ b/src/TestRunner.ts
@@ -84,6 +84,9 @@ export class TestRunner {
 			args.push(`--Tests:${node.id}`);
 		args.push('--Parallel');
 		args.push(`--logger:trx;LogFileName=${testOutputFile.fsPath}`);
+		const settingsPath = this.configManager.get('settingsPath');
+		if (settingsPath)
+			args.push(`--Settings:${settingsPath}`);
 		this.TriggerRunningEvents(node);
 		const { print, finish } = this.output.getTestOutputHandler(node.type === 'test' ? getMethodName(node.id) : node.id);
 		this.Runningtest = new Command(


### PR DESCRIPTION
Closes #50 

This adds a new config property `settingsPath` which can be used to pass a path to a .runsettings file via the `--Settings` of vstest.